### PR TITLE
fix: cli template vars

### DIFF
--- a/libraries/RW/CLI/local_process.py
+++ b/libraries/RW/CLI/local_process.py
@@ -1,7 +1,7 @@
 """ TODO: should be incorporated into platform behaviour
  Acts as interoperable layer between ShellRequest/Response and local processes - hacky
 """
-import os, subprocess, shlex, glob, importlib, traceback, sys, tempfile, shutil
+import os, re, subprocess, shlex, glob, importlib, traceback, sys, tempfile, shutil
 import logging
 
 from RW import platform
@@ -10,7 +10,7 @@ from RW.Core import Core
 logger = logging.getLogger(__name__)
 
 PWD = "."
-
+RF_ENV_PATTERN = re.compile(r'\\%(?=\{)')
 
 def _deserialize_secrets(request_secrets: list[platform.ShellServiceRequestSecret] = []) -> list:
     ds_secrets = [
@@ -27,9 +27,8 @@ def execute_local_command(
     timeout_seconds: int = 60,
 ):
     # handles edge case where CLI tool syntax matches robotframework env vars and has to be escaped
-    rf_env_escape_pattern = re.compile(r'\\%(?=\{)')
-    cmd = rf_env_escape_pattern.sub('%', cmd)
- 
+    cmd = RF_ENV_PATTERN.sub('%', cmd)
+
     USER_ENV: str = os.getenv("USER", None)
     # logging.info(f"Local process user detected as: {USER_ENV}")
     # if not USER_ENV:

--- a/libraries/RW/CLI/local_process.py
+++ b/libraries/RW/CLI/local_process.py
@@ -26,6 +26,10 @@ def execute_local_command(
     files: dict = {},
     timeout_seconds: int = 60,
 ):
+    # handles edge case where CLI tool syntax matches robotframework env vars and has to be escaped
+    rf_env_escape_pattern = re.compile(r'\\%(?=\{)')
+    cmd = rf_env_escape_pattern.sub('%', cmd)
+ 
     USER_ENV: str = os.getenv("USER", None)
     # logging.info(f"Local process user detected as: {USER_ENV}")
     # if not USER_ENV:


### PR DESCRIPTION
- provides a quick fix for template cli vars that need to be passed through robot framework / escaped appropriately