### PR TITLE
add configurable timeouts

### DIFF
--- a/codebundles/azure-cmd/runbook.robot
+++ b/codebundles/azure-cmd/runbook.robot
@@ -20,7 +20,7 @@ ${TASK_TITLE}
     [Tags]    azure    cli    generic
     ${rsp}=    RW.CLI.Run Cli
     ...    cmd=${AZURE_COMMAND}
-    ...    timeout_seconds=1200
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    Command stdout: ${rsp.stdout}
     RW.Core.Add Pre To Report    Command stderr: ${rsp.stderr}
@@ -44,3 +44,9 @@ Suite Initialization
     ...    description=The name of the task to run. This is useful for helping find this generic task with RunWhen Digital Assistants. 
     ...    pattern=\w*
     ...    example="Count the number of pods in the namespace"
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300

--- a/codebundles/azure-cmd/sli.robot
+++ b/codebundles/azure-cmd/sli.robot
@@ -21,6 +21,7 @@ ${TASK_TITLE}
     [Tags]    azure    cli    generic
     ${rsp}=    RW.CLI.Run Cli
     ...    cmd=${AZURE_COMMAND}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     RW.Core.Push Metric     ${rsp.stdout}
 
 *** Keywords ***
@@ -40,3 +41,9 @@ Suite Initialization
     ...    description=The name of the task to run. This is useful for helping find this generic task with RunWhen Digital Assistants. 
     ...    pattern=\w*
     ...    example="Count the number of pods in the namespace"
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=60
+    ...    default=60

--- a/codebundles/azure-stdout-issue/runbook.robot
+++ b/codebundles/azure-stdout-issue/runbook.robot
@@ -21,7 +21,7 @@ ${TASK_TITLE}
     [Tags]    azure    cli    generic
     ${rsp}=    RW.CLI.Run Cli
     ...    cmd=${AZURE_COMMAND}
-    ...    timeout_seconds=1200
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ${history}=    RW.CLI.Pop Shell History
     ${STDOUT}=    Set Variable    ${rsp.stdout}
     IF    """${rsp.stdout}""" != ""
@@ -84,4 +84,10 @@ Suite Initialization
     ...    pattern=\w*
     ...    example=3
     ...    default=3
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300
 

--- a/codebundles/azure-stdout-issue/sli.robot
+++ b/codebundles/azure-stdout-issue/sli.robot
@@ -22,6 +22,7 @@ ${TASK_TITLE}
     [Tags]    azure    cli    generic
     ${rsp}=    RW.CLI.Run Cli
     ...    cmd=${AZURE_COMMAND}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ${history}=    RW.CLI.Pop Shell History
     ${STDOUT}=    Set Variable    ${rsp.stdout}
     IF    """${rsp.stdout}""" != ""
@@ -47,3 +48,9 @@ Suite Initialization
     ...    description=The name of the task to run. This is useful for helping find this generic task with RunWhen Digital Assistants. 
     ...    pattern=\w*
     ...    example="Count the number of pods in the namespace"
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=60
+    ...    default=60

--- a/codebundles/git-script-cmd-env/runbook.robot
+++ b/codebundles/git-script-cmd-env/runbook.robot
@@ -96,7 +96,7 @@ ${TASK_TITLE}
     ...        secret_file__ENV_VAR_8_VALUE=${ENV_VAR_8_VALUE}
     ...        secret_file__ENV_VAR_9_VALUE=${ENV_VAR_9_VALUE}
     ...        secret_file__ENV_VAR_10_VALUE=${ENV_VAR_10_VALUE}
-    ...        timeout_seconds=1800
+    ...        timeout_seconds=${TIMEOUT_SECONDS}
 
     ${history}=    RW.CLI.Pop Shell History
 
@@ -293,7 +293,13 @@ Suite Initialization
     ...    pattern=.*
     ...    example=
     ...    default=Execute Script with Environment Variables
-    
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=1800
+    ...    default=1800
+
     # Set all suite variables
     Set Suite Variable    ${SSH_PRIVATE_KEY}
     Set Suite Variable    ${kubeconfig}
@@ -319,3 +325,4 @@ Suite Initialization
     Set Suite Variable    ${ENV_VAR_10_VALUE}
     Set Suite Variable    ${SCRIPT_COMMAND}
     Set Suite Variable    ${TASK_TITLE} 
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/git-script-cmd-env/sli.robot
+++ b/codebundles/git-script-cmd-env/sli.robot
@@ -94,7 +94,7 @@ ${TASK_TITLE}
     ...        secret_file__ENV_VAR_8_VALUE=${ENV_VAR_8_VALUE}
     ...        secret_file__ENV_VAR_9_VALUE=${ENV_VAR_9_VALUE}
     ...        secret_file__ENV_VAR_10_VALUE=${ENV_VAR_10_VALUE}
-    ...        timeout_seconds=1800
+    ...        timeout_seconds=${TIMEOUT_SECONDS}
 
     
     # Push 1 for success (healthy), 0 for failure (unhealthy)
@@ -286,6 +286,13 @@ Suite Initialization
     ...    pattern=.*
     ...    example=Check Application Health from Private Repository
     ...    default=Execute Script Metric with Environment Variables
+
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=120
+    ...    default=120
     
     # Set all suite variables
     Set Suite Variable    ${SSH_PRIVATE_KEY}
@@ -311,4 +318,5 @@ Suite Initialization
     Set Suite Variable    ${ENV_VAR_10_NAME}
     Set Suite Variable    ${ENV_VAR_10_VALUE}
     Set Suite Variable    ${SCRIPT_COMMAND}
-    Set Suite Variable    ${TASK_TITLE} 
+    Set Suite Variable    ${TASK_TITLE}
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/git-script-cmd-json/runbook.robot
+++ b/codebundles/git-script-cmd-json/runbook.robot
@@ -75,7 +75,7 @@ ${TASK_TITLE}
     ...        secret_file__GIT_USERNAME=${GIT_USERNAME}
     ...        secret_file__GIT_TOKEN=${GIT_TOKEN}
     ...        secret_file__ADDITIONAL_SECRETS=${ADDITIONAL_SECRETS}
-    ...        timeout_seconds=1800
+    ...        timeout_seconds=${TIMEOUT_SECONDS}
 
     ${history}=    RW.CLI.Pop Shell History
 
@@ -143,7 +143,14 @@ Suite Initialization
     ...    pattern=.*
     ...    example=Deploy Application from Private Repository
     ...    default=Execute Script with Secrets
-    
+
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=1800
+    ...    default=1800
+
     # Set suite variables
     Set Suite Variable    ${SSH_PRIVATE_KEY}
     Set Suite Variable    ${GIT_USERNAME}
@@ -152,3 +159,4 @@ Suite Initialization
     Set Suite Variable    ${kubeconfig}
     Set Suite Variable    ${SCRIPT_COMMAND}
     Set Suite Variable    ${TASK_TITLE} 
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/git-script-cmd-json/sli.robot
+++ b/codebundles/git-script-cmd-json/sli.robot
@@ -75,7 +75,7 @@ ${TASK_TITLE}
     ...        secret_file__GIT_USERNAME=${GIT_USERNAME}
     ...        secret_file__GIT_TOKEN=${GIT_TOKEN}
     ...        secret_file__ADDITIONAL_SECRETS=${ADDITIONAL_SECRETS}
-    ...        timeout_seconds=1800
+    ...        timeout_seconds=${TIMEOUT_SECONDS}
     
     # Push 1 for success (healthy), 0 for failure (unhealthy)
     ${metric_value}=    Set Variable If    ${rsp.returncode} == 0    1    0
@@ -152,7 +152,14 @@ Suite Initialization
     ...    pattern=.*
     ...    example=Check Application Health from Private Repository
     ...    default=Execute Script Metric with Secrets
-    
+
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=120
+    ...    default=120
+
     # Set suite variables
     Set Suite Variable    ${SSH_PRIVATE_KEY}
     Set Suite Variable    ${GIT_USERNAME}
@@ -160,4 +167,5 @@ Suite Initialization
     Set Suite Variable    ${ADDITIONAL_SECRETS}
     Set Suite Variable    ${kubeconfig}
     Set Suite Variable    ${SCRIPT_COMMAND}
-    Set Suite Variable    ${TASK_TITLE} 
+    Set Suite Variable    ${TASK_TITLE}
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/k8s-kubectl-cmd/runbook.robot
+++ b/codebundles/k8s-kubectl-cmd/runbook.robot
@@ -21,7 +21,7 @@ ${TASK_TITLE}
     ...    cmd=${KUBECTL_COMMAND}
     ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
     ...    secret_file__kubeconfig=${kubeconfig}
-    ...    timeout_seconds=1200
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    Command stdout: ${rsp.stdout}
     RW.Core.Add Pre To Report    Command stderr: ${rsp.stderr}
@@ -46,3 +46,9 @@ Suite Initialization
     ...    description=The name of the task to run. This is useful for helping find this generic task with RunWhen Digital Assistants. 
     ...    pattern=\w*
     ...    example="Count the number of pods in the namespace"
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300

--- a/codebundles/k8s-kubectl-cmd/sli.robot
+++ b/codebundles/k8s-kubectl-cmd/sli.robot
@@ -21,6 +21,7 @@ ${TASK_TITLE}
     ...    cmd=${KUBECTL_COMMAND}
     ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     RW.Core.Push Metric    ${rsp.stdout}
 
 *** Keywords ***
@@ -41,3 +42,9 @@ Suite Initialization
     ...    description=The name of the task to run. This is useful for helping find this generic task with RunWhen Digital Assistants. 
     ...    pattern=\w*
     ...    example="Count the number of pods in the namespace"
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=120
+    ...    default=120

--- a/codebundles/k8s-stdout-issue/runbook.robot
+++ b/codebundles/k8s-stdout-issue/runbook.robot
@@ -22,7 +22,7 @@ ${TASK_TITLE}
     ...    cmd=${KUBECTL_COMMAND}
     ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
     ...    secret_file__kubeconfig=${kubeconfig}
-    ...    timeout_seconds=1200
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
 
     ${history}=    RW.CLI.Pop Shell History
     ${STDOUT}=    Set Variable    ${rsp.stdout}
@@ -89,4 +89,9 @@ Suite Initialization
     ...    pattern=\w*
     ...    example=3
     ...    default=3
-
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300

--- a/codebundles/k8s-stdout-issue/sli.robot
+++ b/codebundles/k8s-stdout-issue/sli.robot
@@ -23,6 +23,7 @@ ${TASK_TITLE}
     ...    cmd=${KUBECTL_COMMAND}
     ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ${history}=    RW.CLI.Pop Shell History
     ${STDOUT}=    Set Variable    ${rsp.stdout}
     IF    """${rsp.stdout}""" != ""
@@ -50,4 +51,10 @@ Suite Initialization
     ...    description=The name of the task to run. This is useful for helping find this generic task with RunWhen Digital Assistants. 
     ...    pattern=\w*
     ...    example="Count the number of pods in the namespace"
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=120
+    ...    default=120
 


### PR DESCRIPTION
generic commands had hardcoded timeouts - these are now configurable with some defaults

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces hardcoded `timeout_seconds` with user-configurable `TIMEOUT_SECONDS` across Azure, Kubernetes, and Git script bundles, adding imports, defaults, and suite variable wiring.
> 
> - **Configurable timeouts**
>   - **Azure**: Use `${TIMEOUT_SECONDS}` in `codebundles/azure-cmd/{runbook,sli}.robot` and `codebundles/azure-stdout-issue/{runbook,sli}.robot`; add user variable imports with defaults (60–300s).
>   - **Kubernetes**: Use `${TIMEOUT_SECONDS}` in `codebundles/k8s-kubectl-cmd/{runbook,sli}.robot` and `codebundles/k8s-stdout-issue/{runbook,sli}.robot`; add user variable imports with defaults (120–300s).
>   - **Git script bundles**: Use `${TIMEOUT_SECONDS}` in `codebundles/git-script-cmd-env/{runbook,sli}.robot` and `codebundles/git-script-cmd-json/{runbook,sli}.robot`; import user variable with defaults (120–1800s) and set as suite variable.
>   - Minor: ensure `${TIMEOUT_SECONDS}` examples/defaults documented; set suite variables where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3a95bc1240d6f728398b9783847bc72c341f8e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->