### PR TITLE
Fix/import

### DIFF
--- a/codebundles/git-script-cmd-env/runbook.robot
+++ b/codebundles/git-script-cmd-env/runbook.robot
@@ -32,7 +32,7 @@ ${TASK_TITLE}
     Set To Dictionary    ${env_dict}    PATH=${OS_PATH}
     
     # Build export commands for environment variables (reading from secure files)
-    ${env_exports}=    Set Variable    ""
+    ${env_exports}=    Set Variable    ${EMPTY}
     IF    $ENV_VAR_1_NAME != "" and $ENV_VAR_1_VALUE.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export ${ENV_VAR_1_NAME}="$(cat ./${ENV_VAR_1_VALUE.key})" && 
     END
@@ -65,14 +65,20 @@ ${TASK_TITLE}
     END
     
     # Setup KUBECONFIG if provided
-    IF    $kubeconfig != ''
+    TRY
         Set To Dictionary    ${env_dict}    KUBECONFIG=./${kubeconfig.key}
+    EXCEPT
+        Log    kubeconfig not provided, skipping    DEBUG
     END
     
     # Setup SSH if provided (using secure file approach)
-    ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
-        ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+    ${ssh_setup}=    Set Variable    ${EMPTY}
+    TRY
+        IF    $SSH_PRIVATE_KEY.value != ""
+            ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+        END
+    EXCEPT
+        Log    SSH_PRIVATE_KEY not provided, skipping    DEBUG
     END
     
     # Build command parts explicitly to avoid concatenation issues

--- a/codebundles/git-script-cmd-env/sli.robot
+++ b/codebundles/git-script-cmd-env/sli.robot
@@ -29,7 +29,7 @@ ${TASK_TITLE}
     Set To Dictionary    ${env_dict}    PATH=${OS_PATH}
     
     # Build export commands for environment variables (reading from secure files)
-    ${env_exports}=    Set Variable    ""
+    ${env_exports}=    Set Variable    ${EMPTY}
     IF    $ENV_VAR_1_NAME != "" and $ENV_VAR_1_VALUE.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export ${ENV_VAR_1_NAME}="$(cat ./${ENV_VAR_1_VALUE.key})" && 
     END
@@ -62,14 +62,20 @@ ${TASK_TITLE}
     END
     
     # Setup KUBECONFIG if provided
-    IF    $kubeconfig != ''
+    TRY
         Set To Dictionary    ${env_dict}    KUBECONFIG=./${kubeconfig.key}
+    EXCEPT
+        Log    kubeconfig not provided, skipping    DEBUG
     END
     
     # Setup SSH if provided (using secure file approach)
-    ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
-        ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+    ${ssh_setup}=    Set Variable    ${EMPTY}
+    TRY
+        IF    $SSH_PRIVATE_KEY.value != ""
+            ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+        END
+    EXCEPT
+        Log    SSH_PRIVATE_KEY not provided, skipping    DEBUG
     END
     
     # Build command parts explicitly to avoid concatenation issues

--- a/codebundles/git-script-cmd-json/runbook.robot
+++ b/codebundles/git-script-cmd-json/runbook.robot
@@ -33,38 +33,55 @@ ${TASK_TITLE}
     Set To Dictionary    ${env_dict}    PATH=${OS_PATH}
     
     # Build export commands for all secrets (reading from secure files)
-    ${env_exports}=    Set Variable    ""
+    ${env_exports}=    Set Variable    ${EMPTY}
     
     # Add Git credentials as exports (only if they have values)
-    IF    $GIT_USERNAME != '' and $GIT_USERNAME.value != ""
-        ${env_exports}=    Set Variable    ${env_exports}export GIT_USERNAME="$(cat ./${GIT_USERNAME.key})" && 
+    TRY
+        IF    $GIT_USERNAME.value != ""
+            ${env_exports}=    Set Variable    ${env_exports}export GIT_USERNAME="$(cat ./${GIT_USERNAME.key})" && 
+        END
+    EXCEPT
+        Log    GIT_USERNAME not provided, skipping    DEBUG
     END
-    IF    $GIT_TOKEN != '' and $GIT_TOKEN.value != ""
-        ${env_exports}=    Set Variable    ${env_exports}export GIT_TOKEN="$(cat ./${GIT_TOKEN.key})" && 
+    TRY
+        IF    $GIT_TOKEN.value != ""
+            ${env_exports}=    Set Variable    ${env_exports}export GIT_TOKEN="$(cat ./${GIT_TOKEN.key})" && 
+        END
+    EXCEPT
+        Log    GIT_TOKEN not provided, skipping    DEBUG
     END
     
     # Add additional secrets from JSON (only if JSON is provided)
-    ${has_additional_secrets}=    Run Keyword And Return Status    Variable Should Exist    ${ADDITIONAL_SECRETS.value}
-    IF    ${has_additional_secrets} and $ADDITIONAL_SECRETS.value != ""
-        ${additional_env}=    Evaluate    json.loads('''${ADDITIONAL_SECRETS.value}''')    json
-        FOR    ${key}    ${value}    IN    &{additional_env}
-            ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
+    TRY
+        IF    $ADDITIONAL_SECRETS.value != ""
+            ${additional_env}=    Evaluate    json.loads('''${ADDITIONAL_SECRETS.value}''')    json
+            FOR    ${key}    ${value}    IN    &{additional_env}
+                ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
+            END
         END
+    EXCEPT
+        Log    ADDITIONAL_SECRETS not provided, skipping    DEBUG
     END
     
     # Setup KUBECONFIG if provided
-    IF    $kubeconfig != ''
+    TRY
         Set To Dictionary    ${env_dict}    KUBECONFIG=./${kubeconfig.key}
+    EXCEPT
+        Log    kubeconfig not provided, skipping    DEBUG
     END
     
     # Setup SSH if provided (reading from secure file)
-    ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
-        ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+    ${ssh_setup}=    Set Variable    ${EMPTY}
+    TRY
+        IF    $SSH_PRIVATE_KEY.value != ""
+            ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+        END
+    EXCEPT
+        Log    SSH_PRIVATE_KEY not provided, skipping    DEBUG
     END
     
     # Build command parts explicitly to avoid concatenation issues
-    IF   ${env_exports} == ""
+    IF   $env_exports == ""
         ${full_command}=    Set Variable    ${ssh_setup}${SCRIPT_COMMAND}
     ELSE
         ${full_command}=    Set Variable    ${ssh_setup}${env_exports}${SCRIPT_COMMAND}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch to TRY/EXCEPT-based optional secret handling and use ${EMPTY} for init, improving kubeconfig/SSH and Git credential flows across env/json runbook & SLI.
> 
> - **Robust optional secret handling**:
>   - Wrap `kubeconfig`, `SSH_PRIVATE_KEY`, `GIT_USERNAME`, `GIT_TOKEN`, and `ADDITIONAL_SECRETS` accesses in `TRY/EXCEPT` with debug logs when absent.
> - **Initialization cleanup**:
>   - Replace `""` with `${EMPTY}` for `env_exports` and `ssh_setup` initialization.
> - **Command assembly logic**:
>   - Use `$env_exports == ""` checks consistently when building `full_command`.
> - **Files updated**:
>   - `codebundles/git-script-cmd-env/runbook.robot` and `sli.robot`.
>   - `codebundles/git-script-cmd-json/runbook.robot` and `sli.robot`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ff1bbf97ac702f984530ef4d05b063fb456450c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->