### PR TITLE
Fix/git script secret imports

### DIFF
--- a/codebundles/git-script-cmd-env/runbook.robot
+++ b/codebundles/git-script-cmd-env/runbook.robot
@@ -71,7 +71,7 @@ ${TASK_TITLE}
     
     # Setup SSH if provided (using secure file approach)
     ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY.value != ""
+    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
         ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
     END
     

--- a/codebundles/git-script-cmd-env/runbook.robot
+++ b/codebundles/git-script-cmd-env/runbook.robot
@@ -32,7 +32,7 @@ ${TASK_TITLE}
     Set To Dictionary    ${env_dict}    PATH=${OS_PATH}
     
     # Build export commands for environment variables (reading from secure files)
-    ${env_exports}=    Set Variable    ""
+    ${env_exports}=    Set Variable    ${EMPTY}
     IF    $ENV_VAR_1_NAME != "" and $ENV_VAR_1_VALUE.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export ${ENV_VAR_1_NAME}="$(cat ./${ENV_VAR_1_VALUE.key})" && 
     END
@@ -65,14 +65,20 @@ ${TASK_TITLE}
     END
     
     # Setup KUBECONFIG if provided
-    IF    $kubeconfig != ''
+    TRY
         Set To Dictionary    ${env_dict}    KUBECONFIG=./${kubeconfig.key}
+    EXCEPT
+        Log    kubeconfig not provided, skipping    DEBUG
     END
     
     # Setup SSH if provided (using secure file approach)
-    ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
-        ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+    ${ssh_setup}=    Set Variable    ${EMPTY}
+    TRY
+        IF    $SSH_PRIVATE_KEY.value != ""
+            ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+        END
+    EXCEPT
+        Log    SSH_PRIVATE_KEY not provided, skipping    DEBUG
     END
     
     # Build command parts explicitly to avoid concatenation issues

--- a/codebundles/git-script-cmd-env/sli.robot
+++ b/codebundles/git-script-cmd-env/sli.robot
@@ -29,7 +29,7 @@ ${TASK_TITLE}
     Set To Dictionary    ${env_dict}    PATH=${OS_PATH}
     
     # Build export commands for environment variables (reading from secure files)
-    ${env_exports}=    Set Variable    ""
+    ${env_exports}=    Set Variable    ${EMPTY}
     IF    $ENV_VAR_1_NAME != "" and $ENV_VAR_1_VALUE.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export ${ENV_VAR_1_NAME}="$(cat ./${ENV_VAR_1_VALUE.key})" && 
     END
@@ -62,14 +62,20 @@ ${TASK_TITLE}
     END
     
     # Setup KUBECONFIG if provided
-    IF    $kubeconfig != ''
+    TRY
         Set To Dictionary    ${env_dict}    KUBECONFIG=./${kubeconfig.key}
+    EXCEPT
+        Log    kubeconfig not provided, skipping    DEBUG
     END
     
     # Setup SSH if provided (using secure file approach)
-    ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
-        ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+    ${ssh_setup}=    Set Variable    ${EMPTY}
+    TRY
+        IF    $SSH_PRIVATE_KEY.value != ""
+            ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+        END
+    EXCEPT
+        Log    SSH_PRIVATE_KEY not provided, skipping    DEBUG
     END
     
     # Build command parts explicitly to avoid concatenation issues

--- a/codebundles/git-script-cmd-env/sli.robot
+++ b/codebundles/git-script-cmd-env/sli.robot
@@ -68,7 +68,7 @@ ${TASK_TITLE}
     
     # Setup SSH if provided (using secure file approach)
     ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY.value != ""
+    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
         ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
     END
     

--- a/codebundles/git-script-cmd-json/runbook.robot
+++ b/codebundles/git-script-cmd-json/runbook.robot
@@ -44,8 +44,9 @@ ${TASK_TITLE}
     END
     
     # Add additional secrets from JSON (only if JSON is provided)
-    IF    $ADDITIONAL_SECRETS != '' and $ADDITIONAL_SECRETS.value != ""
-        ${additional_env}=    Evaluate    json.loads(open('./${ADDITIONAL_SECRETS.key}').read())    json
+    ${has_additional_secrets}=    Run Keyword And Return Status    Variable Should Exist    ${ADDITIONAL_SECRETS.value}
+    IF    ${has_additional_secrets} and $ADDITIONAL_SECRETS.value != ""
+        ${additional_env}=    Evaluate    json.loads('''${ADDITIONAL_SECRETS.value}''')    json
         FOR    ${key}    ${value}    IN    &{additional_env}
             ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
         END

--- a/codebundles/git-script-cmd-json/runbook.robot
+++ b/codebundles/git-script-cmd-json/runbook.robot
@@ -36,15 +36,15 @@ ${TASK_TITLE}
     ${env_exports}=    Set Variable    ""
     
     # Add Git credentials as exports (only if they have values)
-    IF    $GIT_USERNAME.value != ""
+    IF    $GIT_USERNAME != '' and $GIT_USERNAME.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export GIT_USERNAME="$(cat ./${GIT_USERNAME.key})" && 
     END
-    IF    $GIT_TOKEN.value != ""
+    IF    $GIT_TOKEN != '' and $GIT_TOKEN.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export GIT_TOKEN="$(cat ./${GIT_TOKEN.key})" && 
     END
     
     # Add additional secrets from JSON (only if JSON is provided)
-    IF    $ADDITIONAL_SECRETS.value != ""
+    IF    $ADDITIONAL_SECRETS != '' and $ADDITIONAL_SECRETS.value != ""
         ${additional_env}=    Evaluate    json.loads(open('./${ADDITIONAL_SECRETS.key}').read())    json
         FOR    ${key}    ${value}    IN    &{additional_env}
             ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
@@ -58,7 +58,7 @@ ${TASK_TITLE}
     
     # Setup SSH if provided (reading from secure file)
     ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY.value != ""
+    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
         ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
     END
     

--- a/codebundles/git-script-cmd-json/runbook.robot
+++ b/codebundles/git-script-cmd-json/runbook.robot
@@ -33,38 +33,55 @@ ${TASK_TITLE}
     Set To Dictionary    ${env_dict}    PATH=${OS_PATH}
     
     # Build export commands for all secrets (reading from secure files)
-    ${env_exports}=    Set Variable    ""
+    ${env_exports}=    Set Variable    ${EMPTY}
     
     # Add Git credentials as exports (only if they have values)
-    IF    $GIT_USERNAME != '' and $GIT_USERNAME.value != ""
-        ${env_exports}=    Set Variable    ${env_exports}export GIT_USERNAME="$(cat ./${GIT_USERNAME.key})" && 
+    TRY
+        IF    $GIT_USERNAME.value != ""
+            ${env_exports}=    Set Variable    ${env_exports}export GIT_USERNAME="$(cat ./${GIT_USERNAME.key})" && 
+        END
+    EXCEPT
+        Log    GIT_USERNAME not provided, skipping    DEBUG
     END
-    IF    $GIT_TOKEN != '' and $GIT_TOKEN.value != ""
-        ${env_exports}=    Set Variable    ${env_exports}export GIT_TOKEN="$(cat ./${GIT_TOKEN.key})" && 
+    TRY
+        IF    $GIT_TOKEN.value != ""
+            ${env_exports}=    Set Variable    ${env_exports}export GIT_TOKEN="$(cat ./${GIT_TOKEN.key})" && 
+        END
+    EXCEPT
+        Log    GIT_TOKEN not provided, skipping    DEBUG
     END
     
     # Add additional secrets from JSON (only if JSON is provided)
-    ${has_additional_secrets}=    Run Keyword And Return Status    Variable Should Exist    ${ADDITIONAL_SECRETS.value}
-    IF    ${has_additional_secrets} and $ADDITIONAL_SECRETS.value != ""
-        ${additional_env}=    Evaluate    json.loads('''${ADDITIONAL_SECRETS.value}''')    json
-        FOR    ${key}    ${value}    IN    &{additional_env}
-            ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
+    TRY
+        IF    $ADDITIONAL_SECRETS.value != ""
+            ${additional_env}=    Evaluate    json.loads('''${ADDITIONAL_SECRETS.value}''')    json
+            FOR    ${key}    ${value}    IN    &{additional_env}
+                ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
+            END
         END
+    EXCEPT
+        Log    ADDITIONAL_SECRETS not provided, skipping    DEBUG
     END
     
     # Setup KUBECONFIG if provided
-    IF    $kubeconfig != ''
+    TRY
         Set To Dictionary    ${env_dict}    KUBECONFIG=./${kubeconfig.key}
+    EXCEPT
+        Log    kubeconfig not provided, skipping    DEBUG
     END
     
     # Setup SSH if provided (reading from secure file)
-    ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
-        ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+    ${ssh_setup}=    Set Variable    ${EMPTY}
+    TRY
+        IF    $SSH_PRIVATE_KEY.value != ""
+            ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
+        END
+    EXCEPT
+        Log    SSH_PRIVATE_KEY not provided, skipping    DEBUG
     END
     
     # Build command parts explicitly to avoid concatenation issues
-    IF   ${env_exports} == ""
+    IF   $env_exports == ""
         ${full_command}=    Set Variable    ${ssh_setup}${SCRIPT_COMMAND}
     ELSE
         ${full_command}=    Set Variable    ${ssh_setup}${env_exports}${SCRIPT_COMMAND}

--- a/codebundles/git-script-cmd-json/sli.robot
+++ b/codebundles/git-script-cmd-json/sli.robot
@@ -34,15 +34,15 @@ ${TASK_TITLE}
     ${env_exports}=    Set Variable    ""
     
     # Add Git credentials as exports (only if they have values)
-    IF    $GIT_USERNAME.value != ""
+    IF    $GIT_USERNAME != '' and $GIT_USERNAME.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export GIT_USERNAME="$(cat ./${GIT_USERNAME.key})" && 
     END
-    IF    $GIT_TOKEN.value != ""
+    IF    $GIT_TOKEN != '' and $GIT_TOKEN.value != ""
         ${env_exports}=    Set Variable    ${env_exports}export GIT_TOKEN="$(cat ./${GIT_TOKEN.key})" && 
     END
     
     # Add additional secrets from JSON (only if JSON is provided)
-    IF    $ADDITIONAL_SECRETS.value != ""
+    IF    $ADDITIONAL_SECRETS != '' and $ADDITIONAL_SECRETS.value != ""
         ${additional_env}=    Evaluate    json.loads(open('./${ADDITIONAL_SECRETS.key}').read())    json
         FOR    ${key}    ${value}    IN    &{additional_env}
             ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
@@ -56,7 +56,7 @@ ${TASK_TITLE}
     
     # Setup SSH if provided (reading from secure file)
     ${ssh_setup}=    Set Variable    ""
-    IF    $SSH_PRIVATE_KEY.value != ""
+    IF    $SSH_PRIVATE_KEY != '' and $SSH_PRIVATE_KEY.value != ""
         ${ssh_setup}=    Set Variable    chmod 600 ./${SSH_PRIVATE_KEY.key} && export GIT_SSH_COMMAND='ssh -i ./${SSH_PRIVATE_KEY.key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' &&
     END
     

--- a/codebundles/git-script-cmd-json/sli.robot
+++ b/codebundles/git-script-cmd-json/sli.robot
@@ -42,8 +42,9 @@ ${TASK_TITLE}
     END
     
     # Add additional secrets from JSON (only if JSON is provided)
-    IF    $ADDITIONAL_SECRETS != '' and $ADDITIONAL_SECRETS.value != ""
-        ${additional_env}=    Evaluate    json.loads(open('./${ADDITIONAL_SECRETS.key}').read())    json
+    ${has_additional_secrets}=    Run Keyword And Return Status    Variable Should Exist    ${ADDITIONAL_SECRETS.value}
+    IF    ${has_additional_secrets} and $ADDITIONAL_SECRETS.value != ""
+        ${additional_env}=    Evaluate    json.loads('''${ADDITIONAL_SECRETS.value}''')    json
         FOR    ${key}    ${value}    IN    &{additional_env}
             ${env_exports}=    Set Variable    ${env_exports}export ${key}="${value}" && 
         END


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Harden secret/env handling across git script tasks by using TRY/EXCEPT and ${EMPTY}, parsing ADDITIONAL_SECRETS from value, and fixing command-assembly conditionals.
> 
> - **git-script-cmd-env (`runbook.robot`, `sli.robot`)**:
>   - Initialize command fragments with `${EMPTY}` instead of empty strings.
>   - Wrap optional secret setup in `TRY/EXCEPT` with debug logs:
>     - `KUBECONFIG` assignment from `kubeconfig`
>     - SSH setup from `SSH_PRIVATE_KEY`
>   - Build full command using `$env_exports` check.
> - **git-script-cmd-json (`runbook.robot`, `sli.robot`)**:
>   - Initialize command fragments with `${EMPTY}` and guard optional secret handling via `TRY/EXCEPT`:
>     - Git creds (`GIT_USERNAME`, `GIT_TOKEN`)
>     - Additional env from `ADDITIONAL_SECRETS`
>     - `KUBECONFIG` and SSH setup
>   - Parse `ADDITIONAL_SECRETS` from `${ADDITIONAL_SECRETS.value}` JSON instead of reading a file.
>   - Correct conditional to `IF $env_exports == ""` when composing the final command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9342309cb8ccdf69e2e03f226e2997d0c93d44c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->