### PR TITLE
update git script sli metrics 

### DIFF
--- a/codebundles/git-script-cmd-env/sli.robot
+++ b/codebundles/git-script-cmd-env/sli.robot
@@ -103,20 +103,50 @@ ${TASK_TITLE}
     ...        timeout_seconds=${TIMEOUT_SECONDS}
 
     
-    # Push 1 for success (healthy), 0 for failure (unhealthy)
-    ${metric_value}=    Set Variable If    ${rsp.returncode} == 0    1    0
-    
-    IF    ${rsp.returncode} != 0
-        RW.Core.Add Issue
-        ...    severity=2
-        ...    expected=Script command should execute successfully
-        ...    actual=Script command failed with return code ${rsp.returncode}
-        ...    title=Script Execution Failed
-        ...    reproduce_hint=Check the script command and environment variables. Verify SSH key and repository access if using Git operations.
-        ...    details=Command: ${SCRIPT_COMMAND}${\n}Return Code: ${rsp.returncode}${\n}Stdout: ${rsp.stdout}${\n}Stderr: ${rsp.stderr}
-        ...    next_steps=1. Verify the SCRIPT_COMMAND syntax is correct\n2. Check that all required environment variables are set with valid values\n3. If using SSH, ensure SSH_PRIVATE_KEY is valid and has access to the repository\n4. If using HTTPS, verify GIT_USERNAME and GIT_TOKEN are correct\n5. Test the script command locally to isolate the issue\n6. Check repository URL and access permissions
+    # Determine metric value based on METRIC_MODE
+    IF    "${METRIC_MODE}" == "output"
+        # Parse metric from stdout (strip whitespace)
+        ${metric_value}=    Strip String    ${rsp.stdout}
+        # Validate that output is a number
+        TRY
+            ${metric_value}=    Convert To Number    ${metric_value}
+        EXCEPT
+            RW.Core.Add Issue
+            ...    severity=2
+            ...    expected=Script output should be a numeric value when METRIC_MODE=output
+            ...    actual=Script output is not a valid number: ${metric_value}
+            ...    title=Invalid Metric Output
+            ...    reproduce_hint=When METRIC_MODE=output, the script stdout must output a single numeric value.
+            ...    details=Command: ${SCRIPT_COMMAND}${\n}Return Code: ${rsp.returncode}${\n}Stdout: ${rsp.stdout}${\n}Stderr: ${rsp.stderr}
+            ...    next_steps=1. Ensure your script outputs only a numeric value to stdout\n2. Use tools like 'jq' or 'grep' to extract numeric values from complex output\n3. Consider using METRIC_MODE=returncode if you cannot output a numeric value
+            ${metric_value}=    Set Variable    0
+        END
+        # Still add issue if command failed, but use the output value
+        IF    ${rsp.returncode} != 0
+            RW.Core.Add Issue
+            ...    severity=2
+            ...    expected=Script command should execute successfully
+            ...    actual=Script command failed with return code ${rsp.returncode}
+            ...    title=Script Execution Failed
+            ...    reproduce_hint=Check the script command and environment variables. Verify SSH key and repository access if using Git operations.
+            ...    details=Command: ${SCRIPT_COMMAND}${\n}Return Code: ${rsp.returncode}${\n}Stdout: ${rsp.stdout}${\n}Stderr: ${rsp.stderr}
+            ...    next_steps=1. Verify the SCRIPT_COMMAND syntax is correct\n2. Check that all required environment variables are set with valid values\n3. If using SSH, ensure SSH_PRIVATE_KEY is valid and has access to the repository\n4. If using HTTPS, verify GIT_USERNAME and GIT_TOKEN are correct\n5. Test the script command locally to isolate the issue\n6. Check repository URL and access permissions
+        END
+    ELSE
+        # Default: Push 1 for success (healthy), 0 for failure (unhealthy)
+        ${metric_value}=    Set Variable If    ${rsp.returncode} == 0    1    0
+        
+        IF    ${rsp.returncode} != 0
+            RW.Core.Add Issue
+            ...    severity=2
+            ...    expected=Script command should execute successfully
+            ...    actual=Script command failed with return code ${rsp.returncode}
+            ...    title=Script Execution Failed
+            ...    reproduce_hint=Check the script command and environment variables. Verify SSH key and repository access if using Git operations.
+            ...    details=Command: ${SCRIPT_COMMAND}${\n}Return Code: ${rsp.returncode}${\n}Stdout: ${rsp.stdout}${\n}Stderr: ${rsp.stderr}
+            ...    next_steps=1. Verify the SCRIPT_COMMAND syntax is correct\n2. Check that all required environment variables are set with valid values\n3. If using SSH, ensure SSH_PRIVATE_KEY is valid and has access to the repository\n4. If using HTTPS, verify GIT_USERNAME and GIT_TOKEN are correct\n5. Test the script command locally to isolate the issue\n6. Check repository URL and access permissions
+        END
     END
-    
     RW.Core.Push Metric    ${metric_value}
 
 
@@ -299,6 +329,13 @@ Suite Initialization
     ...    pattern=\w*
     ...    example=120
     ...    default=120
+
+    ${METRIC_MODE}=    RW.Core.Import User Variable    METRIC_MODE
+    ...    type=string
+    ...    description=How to determine the metric value: 'returncode' (1 for success, 0 for failure) or 'output' (parse metric from stdout). Default is 'returncode'.
+    ...    pattern=^(returncode|output)$
+    ...    example=returncode
+    ...    default=returncode
     
     # Set all suite variables
     Set Suite Variable    ${SSH_PRIVATE_KEY}
@@ -326,3 +363,4 @@ Suite Initialization
     Set Suite Variable    ${SCRIPT_COMMAND}
     Set Suite Variable    ${TASK_TITLE}
     Set Suite Variable    ${TIMEOUT_SECONDS}
+    Set Suite Variable    ${METRIC_MODE}

--- a/codebundles/git-script-cmd-json/sli.robot
+++ b/codebundles/git-script-cmd-json/sli.robot
@@ -204,6 +204,13 @@ Suite Initialization
     ...    example=120
     ...    default=120
 
+    ${METRIC_MODE}=    RW.Core.Import User Variable    METRIC_MODE
+    ...    type=string
+    ...    description=How to determine the metric value: 'returncode' (1 for success, 0 for failure) or 'output' (parse metric from stdout). Default is 'returncode'.
+    ...    pattern=^(returncode|output)$
+    ...    example=returncode
+    ...    default=returncode
+
     # Set suite variables
     Set Suite Variable    ${SSH_PRIVATE_KEY}
     Set Suite Variable    ${GIT_USERNAME}
@@ -213,3 +220,4 @@ Suite Initialization
     Set Suite Variable    ${SCRIPT_COMMAND}
     Set Suite Variable    ${TASK_TITLE}
     Set Suite Variable    ${TIMEOUT_SECONDS}
+    Set Suite Variable    ${METRIC_MODE}


### PR DESCRIPTION
Enhance metric handling in git script commands by introducing METRIC_MODE variable. Implement logic to determine metric value based on either command output or return code, improving error reporting and validation for numeric output. Update documentation for METRIC_MODE usage in both sli.robot files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds flexible metric derivation to the git script SLIs.
> 
> - Introduces `METRIC_MODE` user variable (default `returncode`) in both `git-script-cmd-env/sli.robot` and `git-script-cmd-json/sli.robot`, and wires it into suite variables
> - When `METRIC_MODE=output`, parses `stdout`, validates it as numeric (adds issue and defaults metric to `0` if invalid); still records command failure issues based on return code
> - When `METRIC_MODE=returncode`, retains prior behavior (metric `1/0` from return code) with existing failure issue reporting
> - No other functional changes beyond integrating `METRIC_MODE` into execution and metric push flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a6a2321882554d9b17a18693704a090cb9caa7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->