### PR TITLE
generics sli

### DIFF
--- a/codebundles/generics-editor/sli.robot
+++ b/codebundles/generics-editor/sli.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Documentation       A CodeBundle that supports the Tool Builder in the RunWhen Platform for bash and python scripts. 
+Documentation       A CodeBundle that supports the generics editor in the RunWhen UI for bash and pythong scripts.
 Metadata            Author    theyashl
-Metadata            Display Name    Tool Builder (BASH/PYTHON)
+Metadata            Display Name    Generics Editor (BASH/PYTHON)
 Metadata            Supports    bash    python    RunWhen    Generic
 
 Library             BuiltIn
@@ -34,7 +34,7 @@ ${TASK_TITLE}
     ...    ${decode_op.stdout}
     ...    import json, os
     ...    resp = main()
-    ...    path = os.path.join(os.environ["CODEBUNDLE_TEMP_DIR"], "run_output.json")
+    ...    path = os.path.join(os.environ["CODEBUNDLE_TEMP_DIR"], "metric_data.json")
     ...    f = open(path, "w", encoding="utf-8")
     ...    json.dump(resp, f)
     ...    f.close()
@@ -43,8 +43,8 @@ ${TASK_TITLE}
     ...    Catenate    SEPARATOR=\n
     ...    bash << 'EOF'
     ...    ${decode_op.stdout}
-    ...    ISSUES_FILE="$CODEBUNDLE_TEMP_DIR/run_output.json"
-    ...    exec 3> "$ISSUES_FILE"
+    ...    METRIC_FILE="$CODEBUNDLE_TEMP_DIR/metric_data.json"
+    ...    exec 3> "$METRIC_FILE"
     ...    main
     ...    exec 3>&-
     ...    EOF
@@ -53,39 +53,16 @@ ${TASK_TITLE}
     ...    cmd=${command}
     ...    env=${raw_env_vars}
     ...    &{secret_kwargs}
-
-    ${history}=    RW.CLI.Pop Shell History
     
-    ${run_output_file}=    Set Variable    ${raw_env_vars["CODEBUNDLE_TEMP_DIR"]}/run_output.json
-    ${run_output}=    Evaluate    json.load(open(r'''${run_output_file}''')) if os.path.exists(r'''${run_output_file}''') and os.path.getsize(r'''${run_output_file}''') > 0 else []    modules=json,os
-
-    IF    $RUN_TYPE == 'sli'
-        ${msg}=    Catenate    SEPARATOR=\n    Command stdout: ${rsp.stdout}    Reported Metric: ${run_output}
-        RW.Core.Add Pre To Report    ${msg}
-    ELSE
-        RW.Core.Add Pre To Report    Command stdout: ${rsp.stdout}
-        FOR    ${issue}    IN    @{run_output}
-            RW.Core.Add Issue
-            ...    title=${issue['issue title']}
-            ...    severity=${issue['issue severity']}
-            ...    expected=The script should produce no issues, indicating no errors were found.
-            ...    actual=Found issues output produced by the provided script, indicating errors were found.
-            ...    reproduce_hint=look at the SLX description for more details.
-            ...    next_steps=${issue['issue next steps']}
-            ...    details=${issue['issue description']}
-        END
-    END
-
-    RW.Core.Add Pre To Report    Command stderr: ${rsp.stderr}
-    RW.Core.Add Pre To Report    Commands Used: ${history}
+    ${metric_file}=    Set Variable    ${raw_env_vars["CODEBUNDLE_TEMP_DIR"]}/metric_data.json
+    ${metric}=    Evaluate    json.load(open(r'''${metric_file}''')) if os.path.exists(r'''${metric_file}''') and os.path.getsize(r'''${metric_file}''') > 0 else 0    modules=json,os
+    
+    RW.Core.Push Metric    ${metric}    sub_name=metric
+    RW.Core.Push Metric    ${metric}
 
 
 *** Keywords ***
 Suite Initialization
-    ${RUN_TYPE}=    RW.Core.Import User Variable    RUN_TYPE
-    ...    type=string
-    ...    description="Type of run: runbook or sli"
-    ...    default=runbook
     ${INTERPRETER}=    RW.Core.Import User Variable    INTERPRETER
     ...    type=string
     ...    description="Shell: bash or python"
@@ -133,7 +110,6 @@ Suite Initialization
         Set To Dictionary    ${secret_objs}    ${env_name}    ${secret_obj}
     END
     
-    Set Suite Variable    ${RUN_TYPE}    ${RUN_TYPE}
     Set Suite Variable    ${TASK_TITLE}    ${TASK_TITLE}
     Set Suite Variable    ${INTERPRETER}    ${INTERPRETER}
     Set Suite Variable    ${GEN_CMD}    ${GEN_CMD}

--- a/codebundles/tool-builder/sli.robot
+++ b/codebundles/tool-builder/sli.robot
@@ -34,7 +34,7 @@ ${TASK_TITLE}
     ...    ${decode_op.stdout}
     ...    import json, os
     ...    resp = main()
-    ...    path = os.path.join(os.environ["CODEBUNDLE_TEMP_DIR"], "run_output.json")
+    ...    path = os.path.join(os.environ["CODEBUNDLE_TEMP_DIR"], "metric_data.json")
     ...    f = open(path, "w", encoding="utf-8")
     ...    json.dump(resp, f)
     ...    f.close()
@@ -43,8 +43,8 @@ ${TASK_TITLE}
     ...    Catenate    SEPARATOR=\n
     ...    bash << 'EOF'
     ...    ${decode_op.stdout}
-    ...    ISSUES_FILE="$CODEBUNDLE_TEMP_DIR/run_output.json"
-    ...    exec 3> "$ISSUES_FILE"
+    ...    METRIC_FILE="$CODEBUNDLE_TEMP_DIR/metric_data.json"
+    ...    exec 3> "$METRIC_FILE"
     ...    main
     ...    exec 3>&-
     ...    EOF
@@ -53,39 +53,16 @@ ${TASK_TITLE}
     ...    cmd=${command}
     ...    env=${raw_env_vars}
     ...    &{secret_kwargs}
-
-    ${history}=    RW.CLI.Pop Shell History
     
-    ${run_output_file}=    Set Variable    ${raw_env_vars["CODEBUNDLE_TEMP_DIR"]}/run_output.json
-    ${run_output}=    Evaluate    json.load(open(r'''${run_output_file}''')) if os.path.exists(r'''${run_output_file}''') and os.path.getsize(r'''${run_output_file}''') > 0 else []    modules=json,os
-
-    IF    $RUN_TYPE == 'sli'
-        ${msg}=    Catenate    SEPARATOR=\n    Command stdout: ${rsp.stdout}    Reported Metric: ${run_output}
-        RW.Core.Add Pre To Report    ${msg}
-    ELSE
-        RW.Core.Add Pre To Report    Command stdout: ${rsp.stdout}
-        FOR    ${issue}    IN    @{run_output}
-            RW.Core.Add Issue
-            ...    title=${issue['issue title']}
-            ...    severity=${issue['issue severity']}
-            ...    expected=The script should produce no issues, indicating no errors were found.
-            ...    actual=Found issues output produced by the provided script, indicating errors were found.
-            ...    reproduce_hint=look at the SLX description for more details.
-            ...    next_steps=${issue['issue next steps']}
-            ...    details=${issue['issue description']}
-        END
-    END
-
-    RW.Core.Add Pre To Report    Command stderr: ${rsp.stderr}
-    RW.Core.Add Pre To Report    Commands Used: ${history}
+    ${metric_file}=    Set Variable    ${raw_env_vars["CODEBUNDLE_TEMP_DIR"]}/metric_data.json
+    ${metric}=    Evaluate    json.load(open(r'''${metric_file}''')) if os.path.exists(r'''${metric_file}''') and os.path.getsize(r'''${metric_file}''') > 0 else 0    modules=json,os
+    
+    RW.Core.Push Metric    ${metric}    sub_name=metric
+    RW.Core.Push Metric    ${metric}
 
 
 *** Keywords ***
 Suite Initialization
-    ${RUN_TYPE}=    RW.Core.Import User Variable    RUN_TYPE
-    ...    type=string
-    ...    description="Type of run: runbook or sli"
-    ...    default=runbook
     ${INTERPRETER}=    RW.Core.Import User Variable    INTERPRETER
     ...    type=string
     ...    description="Shell: bash or python"
@@ -133,7 +110,6 @@ Suite Initialization
         Set To Dictionary    ${secret_objs}    ${env_name}    ${secret_obj}
     END
     
-    Set Suite Variable    ${RUN_TYPE}    ${RUN_TYPE}
     Set Suite Variable    ${TASK_TITLE}    ${TASK_TITLE}
     Set Suite Variable    ${INTERPRETER}    ${INTERPRETER}
     Set Suite Variable    ${GEN_CMD}    ${GEN_CMD}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds SLI support and standardizes run output across generics-editor and tool-builder.
> 
> - New `codebundles/*/sli.robot` suites: execute user scripts, write `metric_data.json`, and `RW.Core.Push Metric` from parsed value
> - Runbooks now write/read `CODEBUNDLE_TEMP_DIR/run_output.json` (replacing `issues_data.json`) and conditionally handle output via `RUN_TYPE` (`sli` logs reported metric; otherwise creates issues)
> - Introduces `RUN_TYPE` user variable in runbooks; moves stderr and shell history reporting to the end of task
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 439771c21b20665af5e88932559d92b9fcc43e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->