### PR TITLE
add timeout to tool-builder/generics

### DIFF
--- a/codebundles/generics-editor/runbook.robot
+++ b/codebundles/generics-editor/runbook.robot
@@ -145,3 +145,4 @@ Suite Initialization
     Set Suite Variable    ${GEN_CMD}    ${GEN_CMD}
     Set Suite Variable    ${raw_env_vars}    ${raw_env_vars}
     Set Suite Variable    ${secret_objs}    ${secret_objs}
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/generics-editor/runbook.robot
+++ b/codebundles/generics-editor/runbook.robot
@@ -53,6 +53,7 @@ ${TASK_TITLE}
     ...    cmd=${command}
     ...    env=${raw_env_vars}
     ...    &{secret_kwargs}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
 
     ${history}=    RW.CLI.Pop Shell History
     
@@ -100,7 +101,12 @@ Suite Initialization
     ...    description=A useful task title. This is useful for helping find this generic task with RunWhen Assistants. 
     ...    pattern=\w*
     ...    example="Run a bash command"
-
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300
     # env vars management
     ${env_vars_json}=    RW.Core.Import User Variable    CONFIG_ENV_MAP
     ...    type=string

--- a/codebundles/generics-editor/sli.robot
+++ b/codebundles/generics-editor/sli.robot
@@ -121,3 +121,4 @@ Suite Initialization
     Set Suite Variable    ${GEN_CMD}    ${GEN_CMD}
     Set Suite Variable    ${raw_env_vars}    ${raw_env_vars}
     Set Suite Variable    ${secret_objs}    ${secret_objs}
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/generics-editor/sli.robot
+++ b/codebundles/generics-editor/sli.robot
@@ -53,7 +53,8 @@ ${TASK_TITLE}
     ...    cmd=${command}
     ...    env=${raw_env_vars}
     ...    &{secret_kwargs}
-    
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
+   
     ${metric_file}=    Set Variable    ${raw_env_vars["CODEBUNDLE_TEMP_DIR"]}/metric_data.json
     ${metric}=    Evaluate    json.load(open(r'''${metric_file}''')) if os.path.exists(r'''${metric_file}''') and os.path.getsize(r'''${metric_file}''') > 0 else 0    modules=json,os
     
@@ -77,7 +78,12 @@ Suite Initialization
     ...    description=A useful task title. This is useful for helping find this generic task with RunWhen Assistants. 
     ...    pattern=\w*
     ...    example="Run a bash command"
-
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300
     # env vars management
     ${env_vars_json}=    RW.Core.Import User Variable    CONFIG_ENV_MAP
     ...    type=string

--- a/codebundles/tool-builder/runbook.robot
+++ b/codebundles/tool-builder/runbook.robot
@@ -145,3 +145,4 @@ Suite Initialization
     Set Suite Variable    ${GEN_CMD}    ${GEN_CMD}
     Set Suite Variable    ${raw_env_vars}    ${raw_env_vars}
     Set Suite Variable    ${secret_objs}    ${secret_objs}
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/tool-builder/runbook.robot
+++ b/codebundles/tool-builder/runbook.robot
@@ -53,6 +53,7 @@ ${TASK_TITLE}
     ...    cmd=${command}
     ...    env=${raw_env_vars}
     ...    &{secret_kwargs}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
 
     ${history}=    RW.CLI.Pop Shell History
     
@@ -100,7 +101,12 @@ Suite Initialization
     ...    description=A useful task title. This is useful for helping find this generic task with RunWhen Assistants. 
     ...    pattern=\w*
     ...    example="Run a bash command"
-
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300
     # env vars management
     ${env_vars_json}=    RW.Core.Import User Variable    CONFIG_ENV_MAP
     ...    type=string

--- a/codebundles/tool-builder/sli.robot
+++ b/codebundles/tool-builder/sli.robot
@@ -121,3 +121,4 @@ Suite Initialization
     Set Suite Variable    ${GEN_CMD}    ${GEN_CMD}
     Set Suite Variable    ${raw_env_vars}    ${raw_env_vars}
     Set Suite Variable    ${secret_objs}    ${secret_objs}
+    Set Suite Variable    ${TIMEOUT_SECONDS}

--- a/codebundles/tool-builder/sli.robot
+++ b/codebundles/tool-builder/sli.robot
@@ -53,6 +53,7 @@ ${TASK_TITLE}
     ...    cmd=${command}
     ...    env=${raw_env_vars}
     ...    &{secret_kwargs}
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     
     ${metric_file}=    Set Variable    ${raw_env_vars["CODEBUNDLE_TEMP_DIR"]}/metric_data.json
     ${metric}=    Evaluate    json.load(open(r'''${metric_file}''')) if os.path.exists(r'''${metric_file}''') and os.path.getsize(r'''${metric_file}''') > 0 else 0    modules=json,os
@@ -77,7 +78,12 @@ Suite Initialization
     ...    description=A useful task title. This is useful for helping find this generic task with RunWhen Assistants. 
     ...    pattern=\w*
     ...    example="Run a bash command"
-
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=The amount of seconds before the command is killed. 
+    ...    pattern=\w*
+    ...    example=300
+    ...    default=300
     # env vars management
     ${env_vars_json}=    RW.Core.Import User Variable    CONFIG_ENV_MAP
     ...    type=string


### PR DESCRIPTION
adds configurable timeout to these codebundles with a default of 5min

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable execution timeout across generics-editor and tool-builder bundles.
> 
> - Introduces `TIMEOUT_SECONDS` user variable (default `300`) and sets it in suite initialization
> - Passes `timeout_seconds=${TIMEOUT_SECONDS}` to `RW.CLI.Run Cli` in `runbook.robot` and `sli.robot` for both bundles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfea4874ea510d4dd8811217d8b115ad14efc94d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->